### PR TITLE
GitHub migration

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -1,0 +1,5 @@
+# Canonical author names after migration from Subversion for nicer (short)log.
+
+# Stefan Löffler
+Stefan Löffler <st.loeffler@gmail.com>  <st.loeffler@9a2a4a0b-1251-0410-9248-99fc04669920>
+Stefan Löffler <st.loeffler@gmail.com>  <st.loeffler@gmail.com@9a2a4a0b-1251-0410-9248-99fc04669920>

--- a/src/Makefile
+++ b/src/Makefile
@@ -2,7 +2,10 @@ LANGS = $(patsubst %/,manual-%,$(wildcard */))
 DISTLANGS = $(patsubst manual-%,dist-%,$(LANGS))
 CLEANLANGS = $(patsubst manual-%,clean-%,$(LANGS))
 DISTCLEANLANGS = $(patsubst manual-%,dist-clean-%,$(LANGS))
-REVNO = $(shell LANG=C; svn info | grep '^Revision: ' | sed 's/Revision: //')
+
+# Be rather specific with '--git-dir' as we do not want to pick up an unrelated
+# outer Git repository in case the TeXworks manual sources come from an archive.
+GIT_COMMIT = $(shell LANG=C; git --git-dir=../.git rev-parse --short HEAD)
 
 .PHONY : all clean dist dist-clean $(LANGS) $(DISTLANGS) $(CLEANLANGS) $(DISTCLEANLANGS)
 
@@ -11,7 +14,7 @@ all : $(LANGS)
 clean : $(CLEANLANGS)
 
 dist : $(DISTLANGS)
-	cd ../html && zip -r TeXworks-manual-html-r$(REVNO).zip TeXworks-manual
+	cd ../html && zip -r TeXworks-manual-html-$(GIT_COMMIT).zip TeXworks-manual
 
 dist-clean : $(DISTCLEANLANGS)
 


### PR DESCRIPTION
Minor fixes and improvements after migration to GitHub. Pretty much what the commit messages say.

It would be great if (after applying my fix) a release of the zipped HTML manual was made here on GitHub. The OS X part of the TeXworks build system still downloads the manual from Google Code and I don't know for how long this will remain available. I'll follow up with a change to the TeXworks build system as soon as a release is made.

If you don't like the `.mailmap` changes, I'll be happy to remove them from this pull request. Or feel free to cherry-pick yourself.
