### PR TITLE
Refernce "Portable Usage" Information

### DIFF
--- a/src/en/installation.tex
+++ b/src/en/installation.tex
@@ -22,6 +22,8 @@ For the Mac\index{TeX distribution@{\TeX} distribution!Mac}: \textbf{MacTeX}\ind
 For Windows\index{TeX distribution@{\TeX} distribution!Windows}: a very popular distribution is \textbf{MiKTeX}\index{TeX distribution@{\TeX} distribution!Windows!MikTeX} (\url{http://www.miktex.org/}). MikTeX has an update programme, which has also been ported to Linux. You can also use the XEmTeX distribution (\url{http://www.xemtex.org/}).
 \end{OSWindows}
 
+For details on portable usage, and changing local configuration locations, please see the section Portable Usage \& Changing the Configuration -- section \ref{sec.portable_configuration} (on page \pageref{sec.portable_configuration}).
+
 \section{Under Windows}\index{installation!Windows}
 
 Most of the larger {\TeX} distributions already contain {\Tw} as a package. Sometimes, these versions even have some distribution-specific enhancements. So, the preferred way of installing {\Tw} on Windows is to use the package manager of your distribution. In this case, you can skip the next few paragraphs. Be sure to read the end of this section, though, as it provides important information about customizing {\Tw} to your needs.


### PR DESCRIPTION
Just before section "2.1 Under Windows"

Proposed new text paragraph insertion :

For details on portable usage, and changing local configuration locations, please see the section Portable Usage \& Changing the Configuration -- section \ref{sec.portable_configuration} (on page \pageref{sec.portable_configuration}).