### PR TITLE
Fix link to svg color names

### DIFF
--- a/src/en/customizing.tex
+++ b/src/en/customizing.tex
@@ -27,7 +27,7 @@ Let us take a closer look at the three parts of each rule. In its most general f
 \end{verbExample}
 The \verb|<fontflags>| can be specified independent of the colours (note, though, that it must always be preceded by a \verb|;|). The background colour (together with the \verb|/|) can be omitted, but if you specify it, you also have to specify the foreground colour.
 
-Each colour can either be specified by an SVG name\footnote{See \url{http://www.w3.org/TR/SVG/types.html#ColorKeywords} for a list of valid names.} or by a hexadecimal value (\verb|#rrggbb|\footnote{Because \verb|#| is also used to mark comments if given as the first character of a line, you need to add a space, tab, or similar before specifying a hexadecimal foreground color.}) similar as in web documents. The \verb|<fontflags>| can be any combination of the letter \verb|B| (bold), \verb|I| (italic), and \verb|U| (underlined).
+Each colour can either be specified by an SVG name\footnote{See \url{https://www.w3.org/TR/SVG11/types.html#ColorKeywords} for a list of valid names.} or by a hexadecimal value (\verb|#rrggbb|\footnote{Because \verb|#| is also used to mark comments if given as the first character of a line, you need to add a space, tab, or similar before specifying a hexadecimal foreground color.}) similar as in web documents. The \verb|<fontflags>| can be any combination of the letter \verb|B| (bold), \verb|I| (italic), and \verb|U| (underlined).
 
 Examples of valid formatting instructions are:
 \begin{verbExample}

--- a/src/fr/customizing.tex
+++ b/src/fr/customizing.tex
@@ -27,7 +27,7 @@ Regardons plus attentivement aux trois parties de chaque règle. Dans sa forme l
 \end{verbExample}
 \verb|<fontflags>| peut spécifier indépendamment des couleurs (notez cependant qu'il doit toujours être précédé d'un \verb|;|). La couleur d'arrière plan (ainsi que le \verb|/|) peut être omise, mais si vous la spécifiez, vous devez aussi spécifier la couleur d'avant plan.
 
-Chaque couleur peut être spécifiée soit par un nom SVG\footnote{Voir \url{http://www.w3.org/TR/SVG/types.html#ColorKeywords} pour une liste de noms valides.}, soit par une valeur hexadécimale (\verb|#rrggbb|\footnote{Parce que \verb|#| est aussi utilisé pour indiquer les commentaires si donné comme premier caractère d'une ligne, vous devez ajouter un espace, une tabulation ou quelque chose de similaire avant de spécifier une couleur hexadécimale d'avant plan.}) similaire aux documents web. Le \verb|<fontflahs>| peut être toute combinaison des lettres \verb|B| (gras), \verb|I| (italique) et \verb|U| (souligné).
+Chaque couleur peut être spécifiée soit par un nom SVG\footnote{Voir \url{https://www.w3.org/TR/SVG11/types.html#ColorKeywords} pour une liste de noms valides.}, soit par une valeur hexadécimale (\verb|#rrggbb|\footnote{Parce que \verb|#| est aussi utilisé pour indiquer les commentaires si donné comme premier caractère d'une ligne, vous devez ajouter un espace, une tabulation ou quelque chose de similaire avant de spécifier une couleur hexadécimale d'avant plan.}) similaire aux documents web. Le \verb|<fontflahs>| peut être toute combinaison des lettres \verb|B| (gras), \verb|I| (italique) et \verb|U| (souligné).
 
 Exemples d'instructions de mise en forme valides:
 \begin{verbExample}


### PR DESCRIPTION
This pr fixes the invalid link to svg color names. Both en and fr versions are fix.

Detailed info:
1. The current link https://www.w3.org/TR/SVG/types.html#ColorKeywords directs to webpage of svg2
2. But svg2 has removed the list of svg color names, leaves the color list svg1.1 only

   > Remove list of color keywords. The list is part of CSS Colors 3 (see [here](https://www.w3.org/TR/css-color-3/#svg-color)) which is referenced normatively and a REC.
   > ref: 
   >  - https://www.w3.org/TR/SVG/changes.html#types
   >  - https://www.w3.org/TR/SVG/changes.html#color

3. Hence this pr changes the link to the svg1.1 version link, https://www.w3.org/TR/SVG11/types.html#ColorKeywords