### PR TITLE
Remove files, generated by dvipng.

### DIFF
--- a/src/en/html/Makefile
+++ b/src/en/html/Makefile
@@ -74,7 +74,7 @@ clean :
 	rm -f index.4ct index.4tc index.dvi index.idv index.idx index.lg index.log index.out index.tmp index.xref index.4dx index.4ix index.ilg index.ind
 
 dist-clean : clean
-	rm -f *.html index.css
+	rm -f *.html index.css index*png
 	rm -rf images/
 
 dist : dist-html

--- a/src/fr/html/Makefile
+++ b/src/fr/html/Makefile
@@ -80,7 +80,7 @@ clean :
 	rm -f index.4ct index.4tc index.dvi index.idv index.idx index.lg index.log index.out index.tmp index.xref index.4dx index.4ix index.ilg index.ind
 
 dist-clean : clean
-	rm -f *.html index.css
+	rm -f *.html index.css index*png
 	rm -rf images/
 
 dist : dist-html


### PR DESCRIPTION
I notice that during build the program dvipng is called. After installing the Debian package and rebuilding I noticed that some files are not removed even by dist-clean. Consider the pull request.