### PR TITLE
Option "imgdir:images/" must not be specified for htlatex.

### DIFF
--- a/src/en/html/Makefile
+++ b/src/en/html/Makefile
@@ -6,7 +6,7 @@ EpsFromPng = images/toolbar1.eps images/toolbar2.eps images/iconTypeset.eps imag
 
 IMAGES = $(Logos) $(EpsFromPdf) $(EpsFromPng)
 
-HTOPTS = "manual,info,2,imgdir:images/,sec-filename,next,index=2,url-enc" "" "-S*"
+HTOPTS = "manual,info,2,sec-filename,next,index=2,url-enc" "" "-S*"
 
 # Ghostscript 9.14/9.15 dropped the 'epswrite' output device in favor of the new
 # 'eps2write' output device. Prefer the latter, but fallback to the former for

--- a/src/fr/html/Makefile
+++ b/src/fr/html/Makefile
@@ -7,7 +7,7 @@ EpsFromJpg = images/rechremp.eps
 
 IMAGES = $(Logos) $(EpsFromPdf) $(EpsFromPng) ${EpsFromJpg}
 
-HTOPTS = "manual,info,2,imgdir:images/,sec-filename,next,index=2,url-enc" "" "-S*"
+HTOPTS = "manual,info,2,sec-filename,next,index=2,url-enc" "" "-S*"
 
 # Ghostscript 9.14/9.15 dropped the 'epswrite' output device in favor of the new
 # 'eps2write' output device. Prefer the latter, but fallback to the former for


### PR DESCRIPTION
While work on packaging the code I noticed that the <img> reference to some images in the HTML code is broken. Not sure, when this happened and why, maybe the behaviour of htlatex changed. The attached patch seems to solve the issue.